### PR TITLE
Fix for bot crashing on user quit.

### DIFF
--- a/user.js
+++ b/user.js
@@ -101,12 +101,12 @@ User.prototype.part = function(/* string or Channel object */ channel) {
     }
 };
 
-User.prototype.quit = function() {
-    var chan,
+User.prototype.quit = function(msg) {
+    var allchans = this.irc.channels,
+        chan,
         idx;
-
-    for(var i=0;i<this.channels.length;i++){
-        chan = this.channels[i];
+    for(var chanName in allchans){
+        chan = allchans[chanName];
         idx = chan.users.indexOf(this.nick);
         if (idx != -1) {
             chan.users.splice(idx, 1);


### PR DESCRIPTION
User.prototype.quit was using this.channels which was a list of strings instead of irc.channels which is a list of objects. This would cause a crash because chan.users was undefined when calling indexOf().
