### PR TITLE
Fixes when a user quits, then rejoins and the user list doesn't get updated properly

### DIFF
--- a/user.js
+++ b/user.js
@@ -112,6 +112,7 @@ User.prototype.quit = function(msg) {
             chan.users.splice(idx, 1);
         }
     }
+	 delete this.irc.users[this.nick];
 };
 
 User.prototype.isOn = function(channel) {


### PR DESCRIPTION
Needed to clean up the irc.users list when a user /quit. If they rejoined, they wouldn't properly get re-added to the channel user list.
