### PR TITLE
Add help plugin (first draft)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 node_modules
+testbot.js

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 ==========================
 * ADDED:
   * package.json
+  * new plugin help - you can add help messages to each plugin (use !help to view the messages)
 * UPDATED:
   * translated textfilter plugin to english 
 

--- a/plugins/help.js
+++ b/plugins/help.js
@@ -13,8 +13,10 @@ Plugin = exports.Plugin = function(irc) {
 	this.title = 'Help Messages';
 	this.version = '0.1';
 	this.author = 'Markus M. May';
+    this.irc = irc;
 
-	this.irc = irc;
+    this.help = 'This plugin provides the functionality to use the ' + irc.config.command + 'help command';
+    this.helpCommands = [irc.config.command + 'help - lists the existing plugins and their commands'];
 
     irc.addTrigger(this, 'help', this.trigHelp);
 };
@@ -32,11 +34,25 @@ Plugin.prototype.trigHelp = function(msg) {
 	params.shift();
     sys.puts("params: " + params[0]);
     if (typeof params[0] == 'undefined') {
-        chan.send('\002Available Plugins:\002');
+        irc.send(u, '\002Available Plugins\002 and their commands:');
         for(var name in irc.plugins) {
+            if (name == 'global') continue;
             var plugin = irc.plugins[name];
-            chan.send('Plugin: ' + plugin.name + ' ' + plugin.title + ' ' + plugin.version + ' ' 
-                + plugin.author);
+            irc.send(u, 'Plugin: ' + plugin.name + ' - ' + plugin.title + 
+                ' - v' + plugin.version + ' by ' + plugin.author);
+
+            var helpMessage = plugin.help;                        
+            if (typeof helpMessage !== 'undefined') {
+                irc.send(u, helpMessage);
+            }
+
+            var helpCommands = plugin.helpCommands;
+            if (typeof helpCommands !== 'undefined') { 
+                for (i in helpCommands) {
+                    irc.send(u, helpCommands[i]);
+                }
+            }
+
         }
     } else {
 		chan.send('The word \002' + params[0] + '\002 is no longer allowed in here!');

--- a/plugins/help.js
+++ b/plugins/help.js
@@ -1,0 +1,44 @@
+/**
+ * Help Plugin - Prints differnt help messages on the 
+ * IRC channel (as a privmessage)
+ *
+ * @author		Markus M. May
+ * @website		http://www.javafreedom.org
+ * @copyright	Markus M. May 2013
+ */
+var sys = require('util');
+
+Plugin = exports.Plugin = function(irc) {
+	this.name = 'help';
+	this.title = 'Help Messages';
+	this.version = '0.1';
+	this.author = 'Markus M. May';
+
+	this.irc = irc;
+
+    irc.addTrigger(this, 'help', this.trigHelp);
+};
+
+Plugin.prototype.trigHelp = function(msg) {
+    sys.puts( "<trigHelp called " + msg)
+	
+    var irc = this.irc, // irc object
+	    c = msg.arguments[0], // channel
+        chan = irc.channels[c], // channel object
+		u = irc.user(msg.prefix), // user
+		m = msg.arguments[1], // message
+        params = m.split(' ');
+
+	params.shift();
+    sys.puts("params: " + params[0]);
+    if (typeof params[0] == 'undefined') {
+        chan.send('\002Available Plugins:\002');
+        for(var name in irc.plugins) {
+            var plugin = irc.plugins[name];
+            chan.send('Plugin: ' + plugin.name + ' ' + plugin.title + ' ' + plugin.version + ' ' 
+                + plugin.author);
+        }
+    } else {
+		chan.send('The word \002' + params[0] + '\002 is no longer allowed in here!');
+    }
+};

--- a/plugins/reload.js
+++ b/plugins/reload.js
@@ -10,16 +10,20 @@ var sys = require('util');
 Plugin = exports.Plugin = function(irc) {
 	this.name = 'reload';
 	this.title = 'Plugin Reloader';
-	this.version = '0.1';
+	this.version = '0.2';
 	this.author = 'Michael Owens';
 
 	this.irc = irc;
 
-	this.irc.addTrigger(this, 'reload', this.trigGezien);
+    this.help = 'This plugin provides the functionality to reload plugins on demand.';
+    this.helpCommands = [irc.config.command + 'reload - reloads a given plugin', 
+                         irc.config.command + 'unload - unloads a given plugin'];    
+
+	this.irc.addTrigger(this, 'reload', this.reloadPlugin);
     this.irc.addTrigger(this, 'unload', this.unloadPlugin);
 };
 
-Plugin.prototype.trigGezien = function(msg) {
+Plugin.prototype.reloadPlugin = function(msg) {
 	var irc = this.irc, // irc object
         c = msg.arguments[0], // channel
         chan = irc.channels[c], // channel object
@@ -28,7 +32,7 @@ Plugin.prototype.trigGezien = function(msg) {
         params = m.split(' ');
 
 	params.shift();
-	irc.send(chan && chan.name || u, 'Reloading plugin: ' + params[0]);
+	irc.send(chan && chan.name || u, 'reloading plugin: ' + params[0]);
 	irc.loadPlugin(params[0]);
 
 

--- a/plugins/textfilter.js
+++ b/plugins/textfilter.js
@@ -12,8 +12,11 @@ Plugin = exports.Plugin = function(irc) {
 	this.title = 'Word filter';
 	this.version = '0.2';
 	this.author = 'Michael Owens, Markus M. May';
-
 	this.irc = irc;
+
+    this.help = 'This plugin provides a textfilter for words not wanted in the channel';
+    this.helpCommands = [irc.config.command + 'addword - adds a word to the textfilter list'];
+
 	this.filters = ['swine', 'politician', 'girl'];
 
     irc.addTrigger(this, 'addword', this.trigAddword);


### PR DESCRIPTION
This will add the "help" command to the available commands, you need to provide two variables to the plugin:
- this.help: a short help message
- this.helpCommands: an array of help messages for each command

as an example these variables are already defined in the textfilter, as well as the reload plugin. The help plugin does contain these variables as well. 
